### PR TITLE
Support annotations errors

### DIFF
--- a/files/aautoscaler.py
+++ b/files/aautoscaler.py
@@ -47,7 +47,7 @@ class AAutoscaler:
         try:
             if not croniter.match(startTime, currentTime):
                 return
-        except Exception as e:
+        except:
             self.logs.error(
                 {'message': 'Error in start-time annotation', 'namespace': namespace, 'deployment': deployName})
             return
@@ -66,7 +66,7 @@ class AAutoscaler:
         try:
             startReplicas = int(
                 deployAnnotations[startReplicasAnnotation])
-        except Exception as e:
+        except:
             startReplicas = 1
 
         if deployReplicas == startReplicas:
@@ -97,7 +97,7 @@ class AAutoscaler:
         try:
             if not croniter.match(stopTime, currentTime):
                 return
-        except Exception as e:
+        except:
             self.logs.error(
                 {'message': 'Error in stop-time annotation', 'namespace': namespace, 'deployment': deployName})
             return
@@ -117,7 +117,7 @@ class AAutoscaler:
         try:
             stopReplicas = int(
                 deployAnnotations[stopReplicasAnnotation])
-        except Exception as e:
+        except:
             stopReplicas = 0
 
         if deployReplicas == stopReplicas:
@@ -148,7 +148,7 @@ class AAutoscaler:
 
             if not croniter.match(restartTime, currentTime):
                 return
-        except Exception as e:
+        except:
             self.logs.error(
                 {'message': 'Error in restart-time annotation', 'namespace': namespace, 'deployment': deployName})
             return
@@ -160,7 +160,7 @@ class AAutoscaler:
         try:
             restartedAt = parser.parse(
                 deploy.spec.template.metadata.annotations['kubectl.kubernetes.io/restartedAt'])
-        except Exception as e:
+        except:
             restartedAt = currentTime - timedelta(days=1)
 
         if ((currentTime - restartedAt).total_seconds() / 60.0) <= 1:

--- a/files/aautoscaler.py
+++ b/files/aautoscaler.py
@@ -117,6 +117,11 @@ class AAutoscaler:
             # For each deployment inside the namespace
             deployments = self.k8s.getDeployments(namespaceName)
             for deploy in deployments:
-                self.__start__(namespaceName, deploy, currentTime)
-                self.__stop__(namespaceName, deploy, currentTime)
-                self.__restart__(namespaceName, deploy, currentTime)
+                deployName = deploy.metadata.name
+                try:
+                    self.__start__(namespaceName, deploy, currentTime)
+                    self.__stop__(namespaceName, deploy, currentTime)
+                    self.__restart__(namespaceName, deploy, currentTime)
+                except:
+                    self.logs.error(
+                        {'message': 'Error in annotations', 'namespace': namespaceName, 'deployment': deployName})

--- a/files/aautoscaler.py
+++ b/files/aautoscaler.py
@@ -47,7 +47,7 @@ class AAutoscaler:
         try:
             if not croniter.match(startTime, currentTime):
                 return
-        except:
+        except Exception as e:
             self.logs.error(
                 {'message': 'Error in start-time annotation', 'namespace': namespace, 'deployment': deployName})
             return
@@ -66,7 +66,7 @@ class AAutoscaler:
         try:
             startReplicas = int(
                 deployAnnotations[startReplicasAnnotation])
-        except:
+        except Exception as e:
             startReplicas = 1
 
         if deployReplicas == startReplicas:
@@ -97,7 +97,7 @@ class AAutoscaler:
         try:
             if not croniter.match(stopTime, currentTime):
                 return
-        except:
+        except Exception as e:
             self.logs.error(
                 {'message': 'Error in stop-time annotation', 'namespace': namespace, 'deployment': deployName})
             return
@@ -117,7 +117,7 @@ class AAutoscaler:
         try:
             stopReplicas = int(
                 deployAnnotations[stopReplicasAnnotation])
-        except:
+        except Exception as e:
             stopReplicas = 0
 
         if deployReplicas == stopReplicas:
@@ -148,7 +148,7 @@ class AAutoscaler:
 
             if not croniter.match(restartTime, currentTime):
                 return
-        except:
+        except Exception as e:
             self.logs.error(
                 {'message': 'Error in restart-time annotation', 'namespace': namespace, 'deployment': deployName})
             return
@@ -160,7 +160,7 @@ class AAutoscaler:
         try:
             restartedAt = parser.parse(
                 deploy.spec.template.metadata.annotations['kubectl.kubernetes.io/restartedAt'])
-        except:
+        except Exception as e:
             restartedAt = currentTime - timedelta(days=1)
 
         if ((currentTime - restartedAt).total_seconds() / 60.0) <= 1:

--- a/files/aautoscaler.py
+++ b/files/aautoscaler.py
@@ -1,9 +1,10 @@
 import os
 from croniter import croniter
-from datetime import date, datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta
 from dateutil import parser
 from logs import Logs
 from k8s import K8s
+
 
 class AAutoscaler:
 
@@ -19,13 +20,15 @@ class AAutoscaler:
             self.k8s = K8s(k8sAPI, k8sToken)
         # Auth via in-cluster configuration, running inside a pod
         elif 'KUBERNETES_SERVICE_HOST' in os.environ:
-            self.logs.info({'message': 'Kubernetes object via in-cluster configuration.'})
+            self.logs.info(
+                {'message': 'Kubernetes object via in-cluster configuration.'})
             self.k8s = K8s()
         else:
-            self.logs.error({'message': 'Error trying to create the Kubernetes object.'})
+            self.logs.error(
+                {'message': 'Error trying to create the Kubernetes object.'})
             raise Exception('Error trying to create the Kubernetes object.')
 
-    def __start__(self, namespace:str, deploy:dict, currentTime:datetime):
+    def __start__(self, namespace: str, deploy: dict, currentTime: datetime):
         '''
             Logic for start the pods
         '''
@@ -34,25 +37,48 @@ class AAutoscaler:
         deployReplicas = deploy.spec.replicas
 
         startAnnotation = 'another-autoscaler/start-time'
-        if startAnnotation in deployAnnotations:
-            self.logs.debug({'message': 'Start time detected.', 'namespace': namespace, 'deployment': deployName})
-            startTime = deployAnnotations[startAnnotation]
+        if startAnnotation not in deployAnnotations:
+            return
 
-            if croniter.match(startTime, currentTime):
-                self.logs.debug({'message': 'Start time Cron expression matched.', 'namespace': namespace, 'deployment': deployName, 'startTime': str(startTime), 'currentTime': str(currentTime)})
+        self.logs.debug({'message': 'Start time detected.',
+                        'namespace': namespace, 'deployment': deployName})
+        startTime = deployAnnotations[startAnnotation]
 
-                # start-replicas
-                startReplicas = 1
-                startReplicasAnnotation = 'another-autoscaler/start-replicas'
-                if startReplicasAnnotation in deployAnnotations:
-                    self.logs.debug({'message': 'Number of replicas.', 'namespace': namespace, 'deployment': deployName, 'startReplicas': deployAnnotations[startReplicasAnnotation]})
-                    startReplicas = int(deployAnnotations[startReplicasAnnotation])
+        try:
+            if not croniter.match(startTime, currentTime):
+                return
+        except:
+            self.logs.error(
+                {'message': 'Error in start-time annotation', 'namespace': namespace, 'deployment': deployName})
+            return
 
-                if deployReplicas != startReplicas:
-                    self.logs.info({'message': 'Deployment set to start.', 'namespace': namespace, 'deployment': deployName, 'startTime': str(startTime), 'availableReplicas': deploy.status.available_replicas, 'startReplicas': str(startReplicas)})
-                    self.k8s.setReplicas(namespace, deployName, startReplicas)
+        self.logs.debug({'message': 'Start time Cron expression matched.', 'namespace': namespace,
+                        'deployment': deployName, 'startTime': str(startTime), 'currentTime': str(currentTime)})
 
-    def __stop__(self, namespace:str, deploy:dict, currentTime:datetime):
+        # start-replicas
+        startReplicas = 1
+        startReplicasAnnotation = 'another-autoscaler/start-replicas'
+        if startReplicasAnnotation not in deployAnnotations:
+            return
+
+        self.logs.debug({'message': 'Number of replicas.', 'namespace': namespace,
+                        'deployment': deployName, 'startReplicas': deployAnnotations[startReplicasAnnotation]})
+        try:
+            startReplicas = int(
+                deployAnnotations[startReplicasAnnotation])
+        except:
+            startReplicas = 1
+
+        if deployReplicas == startReplicas:
+            return
+
+        self.logs.info({'message': 'Deployment set to start.', 'namespace': namespace, 'deployment': deployName,
+                        'startTime': str(startTime),
+                        'availableReplicas': deploy.status.available_replicas,
+                        'startReplicas': str(startReplicas)})
+        self.k8s.setReplicas(namespace, deployName, startReplicas)
+
+    def __stop__(self, namespace: str, deploy: dict, currentTime: datetime):
         '''
             Logic for stop the pods
         '''
@@ -61,25 +87,49 @@ class AAutoscaler:
         deployReplicas = deploy.spec.replicas
 
         stopAnnotation = 'another-autoscaler/stop-time'
-        if stopAnnotation in deployAnnotations:
-            self.logs.debug({'message': 'Stop time detected.', 'namespace': namespace, 'deployment': deployName})
-            stopTime = deployAnnotations[stopAnnotation]
+        if stopAnnotation not in deployAnnotations:
+            return
 
-            if croniter.match(stopTime, currentTime):
-                self.logs.debug({'message': 'Stop time Cron expression matched.', 'namespace': namespace, 'deployment': deployName, 'stopTime': str(stopTime), 'currentTime': str(currentTime)})
+        self.logs.debug({'message': 'Stop time detected.',
+                        'namespace': namespace, 'deployment': deployName})
+        stopTime = deployAnnotations[stopAnnotation]
 
-                # stop-replicas
-                stopReplicas = 0
-                stopReplicasAnnotation = 'another-autoscaler/stop-replicas'
-                if stopReplicasAnnotation in deployAnnotations:
-                    self.logs.debug({'message': 'Number of replicas.', 'namespace': namespace, 'deployment': deployName, 'stopReplicas': deployAnnotations[stopReplicasAnnotation]})
-                    stopReplicas = int(deployAnnotations[stopReplicasAnnotation])
+        try:
+            if not croniter.match(stopTime, currentTime):
+                return
+        except:
+            self.logs.error(
+                {'message': 'Error in stop-time annotation', 'namespace': namespace, 'deployment': deployName})
+            return
 
-                if deployReplicas != stopReplicas:
-                    self.logs.info({'message': 'Deployment set to stop.', 'namespace': namespace, 'deployment': deployName, 'stopTime': str(stopTime), 'availableReplicas': deploy.status.available_replicas, 'stopReplicas': str(stopReplicas)})
-                    self.k8s.setReplicas(namespace, deployName, stopReplicas)
+        self.logs.debug({'message': 'Stop time Cron expression matched.', 'namespace': namespace,
+                        'deployment': deployName, 'stopTime': str(stopTime), 'currentTime': str(currentTime)})
 
-    def __restart__(self, namespace:str, deploy:dict, currentTime:datetime):
+        # stop-replicas
+        stopReplicas = 0
+        stopReplicasAnnotation = 'another-autoscaler/stop-replicas'
+        if stopReplicasAnnotation not in deployAnnotations:
+            return
+
+        self.logs.debug({'message': 'Number of replicas.', 'namespace': namespace,
+                        'deployment': deployName, 'stopReplicas': deployAnnotations[stopReplicasAnnotation]})
+
+        try:
+            stopReplicas = int(
+                deployAnnotations[stopReplicasAnnotation])
+        except:
+            stopReplicas = 0
+
+        if deployReplicas == stopReplicas:
+            return
+
+        self.logs.info({'message': 'Deployment set to stop.', 'namespace': namespace, 'deployment': deployName,
+                        'stopTime': str(stopTime),
+                        'availableReplicas': deploy.status.available_replicas,
+                        'stopReplicas': str(stopReplicas)})
+        self.k8s.setReplicas(namespace, deployName, stopReplicas)
+
+    def __restart__(self, namespace: str, deploy: dict, currentTime: datetime):
         '''
             Logic for restart the pods
         '''
@@ -87,22 +137,38 @@ class AAutoscaler:
         deployAnnotations = deploy.metadata.annotations
 
         restartAnnotation = 'another-autoscaler/restart-time'
-        if restartAnnotation in deployAnnotations:
-            self.logs.debug({'message': 'Restart time detected.', 'namespace': namespace, 'deployment': deployName})
-            restartTime = deployAnnotations[restartAnnotation]
+        if restartAnnotation not in deployAnnotations:
+            return
 
-            if croniter.match(restartTime, currentTime):
-                self.logs.debug({'message': 'Restart time Cron expression matched.', 'namespace': namespace, 'deployment': deployName, 'restartTime': str(restartTime), 'currentTime': str(currentTime)})
+        self.logs.debug({'message': 'Restart time detected.',
+                        'namespace': namespace, 'deployment': deployName})
+        restartTime = deployAnnotations[restartAnnotation]
 
-                # Check if was already restarted
-                try:
-                    restartedAt = parser.parse(deploy.spec.template.metadata.annotations['kubectl.kubernetes.io/restartedAt'])
-                except:
-                    restartedAt = currentTime - timedelta(days=1)
+        try:
 
-                if ((currentTime - restartedAt).total_seconds() / 60.0) > 1:
-                    self.logs.info({'message': 'Deployment set to restart.', 'namespace': namespace, 'deployment': deployName, 'restartTime': str(restartTime), 'currentTime': str(currentTime)})
-                    self.k8s.rolloutDeployment(namespace, deployName)
+            if not croniter.match(restartTime, currentTime):
+                return
+        except:
+            self.logs.error(
+                {'message': 'Error in restart-time annotation', 'namespace': namespace, 'deployment': deployName})
+            return
+
+        self.logs.debug({'message': 'Restart time Cron expression matched.', 'namespace': namespace,
+                        'deployment': deployName, 'restartTime': str(restartTime), 'currentTime': str(currentTime)})
+
+        # Check if was already restarted
+        try:
+            restartedAt = parser.parse(
+                deploy.spec.template.metadata.annotations['kubectl.kubernetes.io/restartedAt'])
+        except:
+            restartedAt = currentTime - timedelta(days=1)
+
+        if ((currentTime - restartedAt).total_seconds() / 60.0) <= 1:
+            return
+
+        self.logs.info({'message': 'Deployment set to restart.', 'namespace': namespace,
+                        'deployment': deployName, 'restartTime': str(restartTime), 'currentTime': str(currentTime)})
+        self.k8s.rolloutDeployment(namespace, deployName)
 
     def execute(self):
         # Current time in UTC format
@@ -117,11 +183,6 @@ class AAutoscaler:
             # For each deployment inside the namespace
             deployments = self.k8s.getDeployments(namespaceName)
             for deploy in deployments:
-                deployName = deploy.metadata.name
-                try:
-                    self.__start__(namespaceName, deploy, currentTime)
-                    self.__stop__(namespaceName, deploy, currentTime)
-                    self.__restart__(namespaceName, deploy, currentTime)
-                except:
-                    self.logs.error(
-                        {'message': 'Error in annotations', 'namespace': namespaceName, 'deployment': deployName})
+                self.__start__(namespaceName, deploy, currentTime)
+                self.__stop__(namespaceName, deploy, currentTime)
+                self.__restart__(namespaceName, deploy, currentTime)

--- a/files/k8s.py
+++ b/files/k8s.py
@@ -5,6 +5,7 @@ from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 from logs import Logs
 
+
 class K8s:
 
     def __init__(self, apiEndpoint:str='', token:str=''):
@@ -21,7 +22,8 @@ class K8s:
             self.CoreV1Api = client.CoreV1Api(client.ApiClient(configuration))
             self.AppsV1Api = client.AppsV1Api(client.ApiClient(configuration))
             self.NetworkingV1Api = client.NetworkingV1Api(client.ApiClient(configuration))
-        # Client via in-cluster configuration, running inside a pod with proper service account
+        # Client via in-cluster configuration,
+        # running inside a pod with proper service account
         else:
             config.load_incluster_config()
             self.CoreV1Api = client.CoreV1Api()

--- a/files/k8s.py
+++ b/files/k8s.py
@@ -20,13 +20,13 @@ class K8s:
             configuration.host = apiEndpoint
             self.CoreV1Api = client.CoreV1Api(client.ApiClient(configuration))
             self.AppsV1Api = client.AppsV1Api(client.ApiClient(configuration))
-            self.ExtensionsV1beta1Api = client.ExtensionsV1beta1Api(client.ApiClient(configuration))
+            self.NetworkingV1Api = client.NetworkingV1Api(client.ApiClient(configuration))
         # Client via in-cluster configuration, running inside a pod with proper service account
         else:
             config.load_incluster_config()
             self.CoreV1Api = client.CoreV1Api()
             self.AppsV1Api = client.AppsV1Api()
-            self.ExtensionsV1beta1Api = client.ExtensionsV1beta1Api()
+            self.NetworkingV1Api = client.NetworkingV1Api()
 
     def getNamespaces(self) -> list:
         '''
@@ -153,7 +153,7 @@ class K8s:
             return False
 
     def getIngress(self, namespace, ingressName):
-        response = self.ExtensionsV1beta1Api.read_namespaced_ingress(namespace=namespace, name=ingressName)
+        response = self.NetworkingV1Api.read_namespaced_ingress(namespace=namespace, name=ingressName)
         return response
 
     def getLogs(self, namespace, podName, containerName, tailLines):

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,4 +1,4 @@
-kubernetes
-schedule
-croniter
-pytz
+kubernetes==23.3.0
+schedule==1.1.0
+croniter==1.3.4
+pytz==2022.1


### PR DESCRIPTION
If there is an error in an annotation, service stops completely.

```
'another-autoscaler/stop-time': '1-59/2 * * *' <- missing last column
'another-autoscaler/stop-replicas': '' <- empty string is not an integer
```