### PR TITLE
Unsafe SSL Access to the k8s API

### DIFF
--- a/files/k8s.py
+++ b/files/k8s.py
@@ -25,10 +25,14 @@ class K8s:
         # Client via in-cluster configuration,
         # running inside a pod with proper service account
         else:
-            config.load_incluster_config()
-            self.CoreV1Api = client.CoreV1Api()
-            self.AppsV1Api = client.AppsV1Api()
-            self.NetworkingV1Api = client.NetworkingV1Api()
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            my_config = client.Configuration()
+            config.load_incluster_config(client_configuration=my_config)
+            my_config.verify_ssl = False
+            
+            self.CoreV1Api = client.CoreV1Api(client.ApiClient(my_config))
+            self.AppsV1Api = client.AppsV1Api(client.ApiClient(my_config))
+            self.NetworkingV1Api = client.NetworkingV1Api(client.ApiClient(my_config))
 
     def getNamespaces(self) -> list:
         '''


### PR DESCRIPTION
In our self-hosted cluster, we use a self-signed SSL certificate. Access to the kube API server fails because of ssl verification errors. In the same spirit as the access with a bearer token, we add the ssl verification skip options for the incluster SSL access.