### PR TITLE
Introduce a "run mode"

### DIFF
--- a/files/main.py
+++ b/files/main.py
@@ -2,13 +2,22 @@ import os
 import schedule
 import time
 from aautoscaler import AAutoscaler
+from logs import Logs
 
 checkEvery = 5  # Check annotations every 5 seconds by default
 if 'CHECK_EVERY' in os.environ:
     checkEvery = int(os.environ['CHECK_EVERY'])
 
+mode = 'daemon'
+if 'MODE' in os.environ:
+    mode = os.environ['MODE']
+
 aautoscaler = AAutoscaler()
-schedule.every(checkEvery).seconds.do(aautoscaler.execute)
-while True:
-    schedule.run_pending()
-    time.sleep(1)
+if mode == 'daemon':
+    schedule.every(checkEvery).seconds.do(aautoscaler.execute)
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+else:
+    Logs(self.__class__.__name__).info({'message': 'Running once then exit.'})
+    aautoscaler.execute()

--- a/files/main.py
+++ b/files/main.py
@@ -19,5 +19,5 @@ if mode == 'daemon':
         schedule.run_pending()
         time.sleep(1)
 else:
-    Logs(self.__class__.__name__).info({'message': 'Running once then exit.'})
+    Logs(__name__).info({'message': 'Running once then exit.'})
     aautoscaler.execute()


### PR DESCRIPTION
We use the autoscaler to turn off certain deployments over the weekend. It seems wasteful to keep a process in our cluster that constantly consumes 100MB of memory just for doing its work on Fridays. So, we have set up the autoscaler as a CronJob, which required some minor changes to the startup code.